### PR TITLE
Fix argument order in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -15,7 +15,7 @@ $ npm install --save is-path-inside
 ```js
 var isPathInside = require('is-path-inside');
 
-isPathInside('a/b', 'a/b/c');
+isPathInside('a/b/c', 'a/b');
 //=> true
 
 isPathInside('x/y', 'a/b/c');


### PR DESCRIPTION
I feel like I'm being monumentally stupid here but... aren't the arguments in the readme completely the wrong way round?
