### PR TITLE
Explicitly set process.cwd inside path.resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var path = require('path');
 var pathIsInside = require('path-is-inside');
 
 module.exports = function (a, b) {
-	a = path.resolve(a);
-	b = path.resolve(b);
+	a = path.resolve(process.cwd(), a);
+	b = path.resolve(process.cwd(), b);
 
 	if (a === b) {
 		return false;

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "resolve"
   ],
   "dependencies": {
-    "path-is-inside": "^1.0.1"
+    "path-is-inside": "^1.0.2"
   },
   "devDependencies": {
-    "ava": "*",
-    "xo": "*"
+    "ava": "0.17.0",
+    "xo": "0.16.0"
   }
 }


### PR DESCRIPTION
I'm mocking ``process.cwd`` into a sandbox directory with one of my projects. Although ``path.resolve`` will by default resolve to your current working directory to handle relative paths, this change explicitly calls ``process.cwd`` to handle tests that mock ``process.cwd``. 

I found this by tracking down [sindresorhus/del](https://github.com/sindresorhus/del) returning an error that I am removing outside of the working directory and to use ``force`` when I was not.

I also pinned the version of [sindresorhus/xo](https://github.com/sindresorhus/xo) to the latest version that worked with ``node 0.10`` so linting would pass.