### PR TITLE
Make the check case-insensitive on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,11 @@ module.exports = (childPath, parentPath) => {
 	childPath = path.resolve(childPath);
 	parentPath = path.resolve(parentPath);
 
+	if (process.platform === 'win32') {
+		childPath = childPath.toLowerCase();
+		parentPath = parentPath.toLowerCase();
+	}
+
 	if (childPath === parentPath) {
 		return false;
 	}

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import test from 'ava';
 import isPathInside from '.';
 
@@ -6,4 +7,20 @@ test('main', t => {
 	t.true(isPathInside('/a/b/c', '/a/b'));
 	t.false(isPathInside('a/b', 'a/b'));
 	t.false(isPathInside('/a/b', '/a/b'));
+});
+
+test('win32', t => {
+	const processPlatform = process.platform;
+	const pathSep = path.sep;
+
+	Object.defineProperty(process, 'platform', {value: 'win32'});
+	Object.defineProperty(path, 'sep', {value: '\\'});
+
+	t.true(isPathInside('A\\b\\c', 'a\\b'));
+	t.false(isPathInside('A\\b', 'a\\b'));
+	t.true(isPathInside('c:\\a\\b\\c\\d', 'C:\\a\\b\\c'));
+	t.false(isPathInside('C:\\a\\b\\c', 'c:\\a\\b\\c'));
+
+	Object.defineProperty(process, 'platform', {value: processPlatform});
+	Object.defineProperty(path, 'sep', {value: pathSep});
 });


### PR DESCRIPTION
Because this package relies on `path-is-inside` which treats windows as case-insensitive, this module should probably do the same otherwise `isPathInside('C:\a\b\c', 'c:\a\b\c') === true`.