### PR TITLE
Fix nested paths with the same base but actually is a different directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,5 +14,8 @@ module.exports = (childPath, parentPath) => {
 		return false;
 	}
 
+	childPath += path.sep;
+	parentPath += path.sep;
+
 	return childPath.startsWith(parentPath);
 };

--- a/test.js
+++ b/test.js
@@ -11,12 +11,15 @@ test('main', t => {
 	t.false(isPathInside('a/b', 'a/b'));
 	t.false(isPathInside('/a/b', '/a/b'));
 	t.false(isPathInside('A/b/c', 'a/b'));
+	t.false(isPathInside('/a/bc/d', '/a/b'));
 });
 
 test('win32', t => {
 	const processPlatform = process.platform;
 	const pathSep = path.sep;
 
+	const {resolve} = path;
+	path.resolve = path.win32.resolve;
 	Object.defineProperty(process, 'platform', {value: 'win32'});
 	Object.defineProperty(path, 'sep', {value: '\\'});
 
@@ -28,7 +31,9 @@ test('win32', t => {
 	t.false(isPathInside('A\\b', 'a\\b'));
 	t.true(isPathInside('c:\\a\\b\\c\\d', 'C:\\a\\b\\c'));
 	t.false(isPathInside('C:\\a\\b\\c', 'c:\\a\\b\\c'));
+	t.false(isPathInside('a\\bc\\d', 'a\\b'));
 
+	path.resolve = resolve;
 	Object.defineProperty(process, 'platform', {value: processPlatform});
 	Object.defineProperty(path, 'sep', {value: pathSep});
 });


### PR DESCRIPTION
`isPathInside('/a/bc/d', '/a/b')` currently returns `true` but should be `false`.